### PR TITLE
ci: add timestamp and commit hash for each commit in develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,22 @@ pipeline {
         }
         stage('Build deb/rpm') {
             stages {
+                // Replace the pkgrel value with the git commit hash to ensure that
+                // each merged PR has unique artifacts and to prevent conflicts between them.
+                // Note that the pkgrel value will remain as it was in the codebase to avoid
+                // conflicts between multiple open PRs
+                stage('Add timestamp and commit hash') {
+                    when {
+                        branch 'develop'
+                    }
+                    steps {
+                        sh'''
+                            export TIMESTAMP=$(date +%s)
+                            export GIT_COMMIT_SHORT=$(git rev-parse HEAD | head -c 8)
+                            sed -i "s/pkgrel=\\".*\\"/pkgrel=\\"$TIMESTAMP+$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
+                        '''
+                    }
+                }
                 stage('Stash') {
                     steps {
                         stash includes: "yap.json,package/**", name: 'binaries'

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-tasks-db"
-pkgver="0.0.3"
-pkgrel="1"
+pkgver="0.0.4"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Tasks database sidecar"
 maintainer="Zextras <packages@zextras.com>"
 section="mail"


### PR DESCRIPTION
- Add command to replace pkgrel for every build in develop with timestamp and commit hash

Refs: IN-712