### PR TITLE
chore: carbonio.target should restart the services not covered by zmcontrol

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-tasks-db"
-pkgver="0.0.4"
+pkgver="0.0.5"
 pkgrel="1"
 pkgdesc="Carbonio Tasks database sidecar"
 maintainer="Zextras <packages@zextras.com>"
@@ -42,14 +42,16 @@ source=(
   "service-protocol.json"
 )
 
-sha256sums=('04e1cecee08385261acd5b72ecc1ad09ad6fd4be44705cff0096be9727d01749'
+sha256sums=(
+  '04e1cecee08385261acd5b72ecc1ad09ad6fd4be44705cff0096be9727d01749'
   '816183bfee31f4492d76010efc59f5af17af1d85875d92aa5366c777b21a329f'
   'e19c3dae9fb03ac5604a1dd43d458fe453e62e3cb306e5e9a8cca72055dee4f1'
   'd426fe19ba6d14b02158688074eee6e84193d0be90de62ff845c2be1e5afeb47'
-  'e00a6afdcc44b379641284258dda67e2bb3566abd288393869055dc9e61fe96f'
+  'b45d9bb62a0ff042a35f8a251b7ee625d9dbd1ee1bc83ff0f46844d903df8303'
   'e31d1e76d7530734922ce14c715e62a005b3ec79a40a4cc35c8c8a5089b79571'
   '8e549e7c6c6dfe32371c03bd0d6be4f0ac82d87426a51080a6c209a91608705d'
-  '81c49d3900c8fdd1fc025746759f802189c19a22f670b778d2ed91be95e30c42')
+  '81c49d3900c8fdd1fc025746759f802189c19a22f670b778d2ed91be95e30c42'
+  )
 backup=(
   "etc/zextras/service-discover/carbonio-tasks-db.hcl"
 )

--- a/package/carbonio-tasks-db-sidecar.service
+++ b/package/carbonio-tasks-db-sidecar.service
@@ -6,6 +6,7 @@
 Description=Carbonio Tasks database sidecar
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -23,4 +24,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target


### PR DESCRIPTION
Refs: [IN-881](https://zextras.atlassian.net/browse/IN-881)

[IN-881]: https://zextras.atlassian.net/browse/IN-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ