### PR TITLE
chore(release): 0.0.6 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.0.6](https://github.com/zextras/carbonio-tasks-db/compare/v0.0.5...v0.0.6) (2026-02-23)
+
 ## [0.0.5](https://github.com/zextras/carbonio-tasks-db/compare/v0.0.4...v0.0.5) (2025-11-28)
 
 ### Bug Fixes

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-tasks-db"
-pkgver="0.0.5"
+pkgver="0.0.6"
 pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Tasks database sidecar"
 maintainer="Zextras <packages@zextras.com>"


### PR DESCRIPTION
🤖 Automated release preparation for v0.0.6