### PR TITLE
ci(jenkins): add defaultPipelineProperties call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 dt3_pipeline(
     repoName: 'carbonio-tasks-db',
     packaging: [


### PR DESCRIPTION
Add missing properties(defaultPipelineProperties()) call before pipeline block, required by Zextras Jenkins shared library standards.