### PR TITLE
feat(packaging): use arch=('any') for architecture-independent package

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Carbonio Tasks database sidecar"
 maintainer="Zextras <packages@zextras.com>"
 section="mail"
 priority="optional"
-arch=('x86_64')
+arch=('any')
 copyright=(
   "2022, Zextras <https://www.zextras.com>"
 )


### PR DESCRIPTION
## Summary

- Replace `arch=('x86_64')` with `arch=('any')` in PKGBUILD since this package does not contain architecture-specific binaries

IN-951