### PR TITLE
chore: [CO-3846] temporary revert to ProtectSystem=yes

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -53,8 +53,8 @@ sha256sums=(
   '04e1cecee08385261acd5b72ecc1ad09ad6fd4be44705cff0096be9727d01749'
   '3e30cee651cfee45866e84fb47640815bfcc73a31b3c8ba632a9ffe12c0aee67'
   'd426fe19ba6d14b02158688074eee6e84193d0be90de62ff845c2be1e5afeb47'
-  '2e9d6de9fc710e731265324d079b2949b309152b58b7500f385c24fbf1df4a6b'
-  '9b6177b1b176ed37d540de275cc682f90c8ad5b6e2bd7ad51d28ce25343265dd'
+  '4f39112da1310a52a22ba50121767dba7c599ae814c77bf90e6668ffe08981e2'
+  '42c09147e70c2760d275bb831f02aff1ae27a3cc84f896d13c141b56668c89ad'
   'e31d1e76d7530734922ce14c715e62a005b3ec79a40a4cc35c8c8a5089b79571'
   '8e549e7c6c6dfe32371c03bd0d6be4f0ac82d87426a51080a6c209a91608705d'
   '81c49d3900c8fdd1fc025746759f802189c19a22f670b778d2ed91be95e30c42'
@@ -100,10 +100,10 @@ package__rocky_8() { _package_legacy; }
 package__ubuntu_jammy() { _package_legacy; }
 
 postinst() {
-  getent group 'carbonio-tasks-db' >/dev/null \
-    || groupadd -r 'carbonio-tasks-db'
-  getent passwd 'carbonio-tasks-db' >/dev/null \
-    || useradd -r -M -g 'carbonio-tasks-db' -s /sbin/nologin 'carbonio-tasks-db'
+  getent group 'carbonio-tasks-db' >/dev/null ||
+    groupadd -r 'carbonio-tasks-db'
+  getent passwd 'carbonio-tasks-db' >/dev/null ||
+    useradd -r -M -g 'carbonio-tasks-db' -s /sbin/nologin 'carbonio-tasks-db'
 
   if [ -d /run/systemd/system ]; then
     systemctl daemon-reload >/dev/null 2>&1 || :

--- a/package/carbonio-tasks-db-sidecar-legacy.service
+++ b/package/carbonio-tasks-db-sidecar-legacy.service
@@ -22,7 +22,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes

--- a/package/carbonio-tasks-db-sidecar.service
+++ b/package/carbonio-tasks-db-sidecar.service
@@ -27,7 +27,11 @@ LimitNOFILE=65536
 
 # Hardening
 PrivateTmp=yes
-ProtectSystem=strict
+#ProtectSystem=strict
+ProtectSystem=yes
+ReadOnlyPaths=/usr
+ReadOnlyPaths=/boot
+ReadOnlyPaths=/efi
 NoNewPrivileges=yes
 PrivateDevices=yes
 ProtectHome=yes


### PR DESCRIPTION
## [CO-3846] Release systemd hardening with `ProtectSystem=yes` for 26.6

For 26.6, units with systemd hardening are released with `ProtectSystem=yes` instead of `ProtectSystem=strict`. The switch to `ProtectSystem=strict` as default is planned for 26.9.

### Change
- Comment out `ProtectSystem=strict` and its associated `ReadWritePaths=` entries.
- Set `ProtectSystem=yes`, keeping only `/usr`, `/boot` and `/efi` read-only via `ReadOnlyPaths`.
- Refresh PKGBUILD checksums where a modified `.service` is a local `source=()` entry.

### Why
With `strict` as default the behavior is correct on new installations, but it imposes a breaking change on upgrades: customers using non-standard paths (secondary volumes, local or NFS backups) would find those writes blocked after the upgrade. Releasing with `ProtectSystem=yes` improves the security baseline without breaking any existing installation on upgrade.

The step to `strict` returns in 26.9, giving partners a full release cycle to review their layouts and prepare overrides where needed. This is a choice of sequencing, not feature cancellation — `strict` remains the end state.

Follows the `carbonio-mailbox` CO-3846 pattern.


[CO-3846]: https://zextras.atlassian.net/browse/CO-3846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ